### PR TITLE
chore: bump node to v12.8.0 (master)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '5a48e127c8cb8ae827f4fead0b527079194b9899',
   'node_version':
-    'v12.4.0',
+    'v12.7.0',
   'nan_version':
     '2ee313aaca52e2b478965ac50eb5082520380d1b',
 

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     '5a48e127c8cb8ae827f4fead0b527079194b9899',
   'node_version':
-    'v12.7.0',
+    'v12.8.0',
   'nan_version':
     '2ee313aaca52e2b478965ac50eb5082520380d1b',
 


### PR DESCRIPTION
Updating Node.js to v12.8.0.

See [all changes in v12.4.0..v12.8.0](https://github.com/nodejs/node/compare/v12.4.0...v12.8.0)

<!--
Original-Node-Version: v12.4.0
-->

Notes: Updated Node.js to v12.8.0.