### PR TITLE
chore: bump chromium to 76.0.3809.83 (6-0-x)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '76.0.3809.77',
+    '76.0.3809.83',
   'node_version':
     '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
 

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '76.0.3809.51',
+    '76.0.3809.73',
   'node_version':
     '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
 

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '76.0.3809.73',
+    '76.0.3809.74',
   'node_version':
     '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
 

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '76.0.3809.74',
+    '76.0.3809.77',
   'node_version':
     '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
 


### PR DESCRIPTION
Updating Chromium to 76.0.3809.83.

See [all changes in 76.0.3809.51..76.0.3809.83](https://chromium.googlesource.com/chromium/src/+log/76.0.3809.51..76.0.3809.83?n=10000&pretty=fuller)

<!--
Original-Version: 76.0.3809.51
-->

Notes: Updated Chromium to 76.0.3809.83.