### PR TITLE
chore: bump chromium to 56a87629be5e93f448557de2b3a23 (master)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '0d4037b120056a87629be5e93f448557de2b3a23',
+    'f2c2dd363eceb723166690bc2a9ada859ce813c5',
   'node_version':
     'v12.4.0',
   'nan_version':

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    'b70127ab9cb85d4d2756fd9b6e04ba4de096dbe4',
+    '818312d3610468b8c0449769b97419c07680e8c2',
   'node_version':
     'v12.4.0',
   'nan_version':

--- a/DEPS
+++ b/DEPS
@@ -149,3 +149,4 @@ hooks = [
 recursedeps = [
   'src',
 ]
+

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '5a48e127c8cb8ae827f4fead0b527079194b9899',
+    'd2ef41d4ad5dc19ba46bdaa61eb1bb6fe5e60384',
   'node_version':
     'v12.4.0',
   'nan_version':

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    'd2ef41d4ad5dc19ba46bdaa61eb1bb6fe5e60384',
+    'b70127ab9cb85d4d2756fd9b6e04ba4de096dbe4',
   'node_version':
     'v12.4.0',
   'nan_version':

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '818312d3610468b8c0449769b97419c07680e8c2',
+    '0d4037b120056a87629be5e93f448557de2b3a23',
   'node_version':
     'v12.4.0',
   'nan_version':


### PR DESCRIPTION
Updating Chromium to 56a87629be5e93f448557de2b3a23 (lkgr).

See [all changes in b8ae827f4fead0b527079194b9899..56a87629be5e93f448557de2b3a23](https://chromium.googlesource.com/chromium/src/+log/5a48e127c8cb8ae827f4fead0b527079194b9899..0d4037b120056a87629be5e93f448557de2b3a23?n=10000&pretty=fuller)

<!--
Original-Version: 9eecb7a9f652bbf84f6437b49c70922b65b38bf3
-->

Notes: no-notes